### PR TITLE
This allows having nested Sortable components

### DIFF
--- a/src/SortableItemMixin.jsx
+++ b/src/SortableItemMixin.jsx
@@ -27,6 +27,7 @@ module.exports = {
     };
     if (!e.target.classList.contains('is-isolated') && this.props.isDraggable) {
       this.props.onSortableItemMouseDown(evt, this.props.sortableIndex);
+      e.stopPropagation();
     }
   },
   outerHeight: function() {


### PR DESCRIPTION
Currently, nesting a Sortable component inside another Sortable components is not possible, because both the internal and external one capture the onMouseDown event.
Imagine a multilevel tree, where you want to sort items inside a folder and also sort the folders inside an external folder.
With this patch, this should work.
